### PR TITLE
Add support for Win10 defaults and non-Anonymous access

### DIFF
--- a/scripts/smb-vuln-ms17-010.nse
+++ b/scripts/smb-vuln-ms17-010.nse
@@ -22,7 +22,7 @@ References:
 ]]
 
 ---
--- @usage nmap -p445 --script smb-vuln-ms17-010 <target>
+-- @usage nmap -p445 --script smb-vuln-ms17-010 [--script-args=username=<user>,domain=<dom>,password=<pass>] <target>
 -- @usage nmap -p445 --script vuln <target>
 --
 -- @output
@@ -77,12 +77,25 @@ hostrule = function(host)
 end
 
 local function check_ms17010(host, port, sharename)
-  local status, smbstate = smb.start_ex(host, true, true, sharename, nil, nil, nil)
+  local username, domain, password, status
+  local overrides = {}
+  local anonguest, smbstate = smb.start_ex(host,true,true,nil,nil,nil,overrides)
+  if not anonguest then
+    username, domain, password = stdnse.get_script_args('username', 'domain', 'password')
+    overrides = smb.get_overrides(username,domain,password,nil,nil,nil)
+    status, smbstate = smb.start_ex(host,true,true,nil,nil,nil,overrides)
+    if not status then
+      stdnse.debug1("Unable to get the server name")
+      return false, smbstate
+    end
+  end
+  local servername = smbstate['server']
+  smb.stop(smbstate)
+  status, smbstate = smb.start_ex(host, true, true, "\\\\".. servername .. "\\" .. sharename, nil, nil, overrides )
   if not status then
     stdnse.debug1("Could not connect to '%s'", sharename)
     return false, string.format("Could not connect to '%s'", sharename)
   else
-    local overrides = {}
     local smb_header, smb_params, smb_cmd
 
     stdnse.debug1("Connected to share '%s'", sharename)

--- a/scripts/smb-vuln-ms17-010.nse
+++ b/scripts/smb-vuln-ms17-010.nse
@@ -22,7 +22,7 @@ References:
 ]]
 
 ---
--- @usage nmap -p445 --script smb-vuln-ms17-010 [--script-args=smbuser=<user>,smbdomain=<dom>,smbpassword=<pass>] <target>
+-- @usage nmap -p445 --script smb-vuln-ms17-010 [--script-args=smbusername=<user>,smbdomain=<dom>,smbpassword=<pass>] <target>
 -- @usage nmap -p445 --script vuln <target>
 --
 -- @output


### PR DESCRIPTION
I've constructed a fully qualified path to the share, to get rid of the nt_status_duplicate_name errors I was getting a lot of.

I've also added optional credentials, for machines that disallow anonymous sessions.